### PR TITLE
Update workspace folder path and VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "cwtools.rules_version": "manual",
-    "cwtools.rules_folder": "C:\\Users\\Camer\\OneDrive\\Personal Projects\\gamedev\\CK3 mod\\CK3 Mod Tools and Guides\\CWTOOLS",
+
     "files.encoding": "utf8bom"
 }

--- a/Lux Renatus RR.code-workspace
+++ b/Lux Renatus RR.code-workspace
@@ -1,7 +1,7 @@
 {
 	"folders": [
 		{
-			"path": "."
+			"path": "C:\\Users\\Camer\\Documents\\Paradox Interactive\\Crusader Kings III\\mod\\Lux Renatus RR"
 		}
 	],
 	"settings": {


### PR DESCRIPTION
Changed the workspace folder path to an absolute path in the code-workspace file and removed CWTools-specific settings from .vscode/settings.json, leaving only the file encoding setting.